### PR TITLE
Fixes issues with latest OC build

### DIFF
--- a/PoExtractor.Core.Tests/PoExtractor.Core.Tests.csproj
+++ b/PoExtractor.Core.Tests/PoExtractor.Core.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PoExtractor.Core/PoExtractor.Core.csproj
+++ b/PoExtractor.Core/PoExtractor.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/PoExtractor.DotNet.CS/PoExtractor.DotNet.CS.csproj
+++ b/PoExtractor.DotNet.CS/PoExtractor.DotNet.CS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PoExtractor.DotNet.VB/PoExtractor.DotNet.VB.csproj
+++ b/PoExtractor.DotNet.VB/PoExtractor.DotNet.VB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PoExtractor.DotNet/PoExtractor.DotNet.csproj
+++ b/PoExtractor.DotNet/PoExtractor.DotNet.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PoExtractor.Core\PoExtractor.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.0" />
   </ItemGroup>
 </Project>

--- a/PoExtractor.Liquid/LiquidProjectProcessor.cs
+++ b/PoExtractor.Liquid/LiquidProjectProcessor.cs
@@ -15,10 +15,8 @@ namespace PoExtractor.Liquid {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiquidProjectProcessor"/>
         /// </summary>
-        /// <param name="configurationAction">the action used to configure <see cref="FluidParserFactory"/>. Custom filters should be registered in the configuration action.</param>
         public LiquidProjectProcessor() {
             var parserFactory = LiquidViewTemplate.Factory;
-
             _parser = parserFactory.CreateParser();
         }
 

--- a/PoExtractor.Liquid/LiquidProjectProcessor.cs
+++ b/PoExtractor.Liquid/LiquidProjectProcessor.cs
@@ -1,11 +1,9 @@
 ﻿using Fluid;
+using OrchardCore.DisplayManagement.Liquid;
 using PoExtractor.Core;
 using PoExtractor.Core.Contracts;
 using PoExtractor.Liquid.MetadataProviders;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace PoExtractor.Liquid {
     /// <summary>
@@ -18,9 +16,8 @@ namespace PoExtractor.Liquid {
         /// Initializes a new instance of the <see cref="LiquidProjectProcessor"/>
         /// </summary>
         /// <param name="configurationAction">the action used to configure <see cref="FluidParserFactory"/>. Custom filters should be registered in the configuration action.</param>
-        public LiquidProjectProcessor(Action<FluidParserFactory> configurationAction) {
-            var parserFactory = new FluidParserFactory();
-            configurationAction?.Invoke(parserFactory);
+        public LiquidProjectProcessor() {
+            var parserFactory = LiquidViewTemplate.Factory;
 
             _parser = parserFactory.CreateParser();
         }

--- a/PoExtractor.Liquid/PoExtractor.Liquid.csproj
+++ b/PoExtractor.Liquid/PoExtractor.Liquid.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>PoExtractor.Liquid</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="1.0.0-beta-9637" />
+    <PackageReference Include="Fluid.Core" Version="1.0.0-beta-9651" />
+    <PackageReference Include="OrchardCore.DisplayManagement.Liquid" Version="1.0.0-rc1-13272" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PoExtractor.OrchardCore/PoExtractor.OrchardCore.csproj
+++ b/PoExtractor.OrchardCore/PoExtractor.OrchardCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>PoExtractor.OrchardCore</AssemblyName>
     <ToolCommandName>extractpo-oc</ToolCommandName>
     <PackAsTool>true</PackAsTool>
@@ -13,11 +13,6 @@
     <Product />
     <Description>.NET Core global tool for extractiong translatable strings from the OrchardCore source files.</Description>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="1.0.0-beta-9637" />
-    <PackageReference Include="OrchardCore.DisplayManagement.Liquid" Version="1.0.0-beta3-71077" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PoExtractor.Core\PoExtractor.Core.csproj" />

--- a/PoExtractor.OrchardCore/PoExtractor.OrchardCore.csproj
+++ b/PoExtractor.OrchardCore/PoExtractor.OrchardCore.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>PoExtractor.OrchardCore</AssemblyName>
     <ToolCommandName>extractpo-oc</ToolCommandName>
     <PackAsTool>true</PackAsTool>
-    <Version>0.3.1-beta3-71077</Version>
+    <Version>0.4.0-rc1-13272</Version>
     <PackageId>PoExtractor.OrchardCore</PackageId>
     <Authors>Lukas Kabrt</Authors>
     <Company />

--- a/PoExtractor.OrchardCore/Program.cs
+++ b/PoExtractor.OrchardCore/Program.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Fluid;
-using OrchardCore.DisplayManagement.Liquid.Tags;
-using OrchardCore.DynamicCache.Liquid;
 using PoExtractor.Core;
 using PoExtractor.Core.Contracts;
 using PoExtractor.Liquid;
@@ -22,7 +19,6 @@ namespace PoExtractor.OrchardCore {
 
             var basePath = args[0];
             var outputBasePath = args[1];
-            var parseLiquid = args.Length > 2 && args[2] == "--liquid";
 
             string[] projectFiles;
             if (Directory.Exists(basePath)) {
@@ -39,9 +35,7 @@ namespace PoExtractor.OrchardCore {
                 new VisualBasicProjectProcessor()
             };
 
-            if (parseLiquid) {
-                processors.Add(new LiquidProjectProcessor(ConfigureFluidParser));
-            };
+            processors.Add(new LiquidProjectProcessor());
 
             foreach (var projectFilePath in projectFiles) {
                 var projectPath = Path.GetDirectoryName(projectFilePath);
@@ -75,48 +69,6 @@ namespace PoExtractor.OrchardCore {
             Console.WriteLine("    input: path to the input directory, all projects at the the path will be processed");
             Console.WriteLine("    output: path to a directory where POT files will be generated");
             Console.WriteLine("    --liquid: include this flag to process .liquid files");
-        }
-
-        private static void ConfigureFluidParser(FluidParserFactory _liquidParseFactory) {
-            _liquidParseFactory.RegisterTag<RenderBodyTag>("render_body");
-            _liquidParseFactory.RegisterTag<RenderSectionTag>("render_section");
-            _liquidParseFactory.RegisterTag<RenderTitleSegmentsTag>("page_title");
-            _liquidParseFactory.RegisterTag<AntiForgeryTokenTag>("antiforgerytoken");
-            _liquidParseFactory.RegisterTag<LayoutTag>("layout");
-
-            _liquidParseFactory.RegisterTag<ClearAlternatesTag>("shape_clear_alternates");
-            _liquidParseFactory.RegisterTag<AddAlternatesTag>("shape_add_alternates");
-            _liquidParseFactory.RegisterTag<ClearWrappers>("shape_clear_wrappers");
-            _liquidParseFactory.RegisterTag<AddWrappersTag>("shape_add_wrappers");
-            _liquidParseFactory.RegisterTag<ClearClassesTag>("shape_clear_classes");
-            _liquidParseFactory.RegisterTag<AddClassesTag>("shape_add_classes");
-            _liquidParseFactory.RegisterTag<ClearAttributesTag>("shape_clear_attributes");
-            _liquidParseFactory.RegisterTag<AddAttributesTag>("shape_add_attributes");
-            _liquidParseFactory.RegisterTag<ShapeTypeTag>("shape_type");
-            _liquidParseFactory.RegisterTag<ShapeDisplayTypeTag>("shape_display_type");
-            _liquidParseFactory.RegisterTag<ShapePositionTag>("shape_position");
-            _liquidParseFactory.RegisterTag<ShapeTabTag>("shape_tab");
-            _liquidParseFactory.RegisterTag<ShapeRemoveItemTag>("shape_remove_item");
-            _liquidParseFactory.RegisterTag<ShapePagerTag>("shape_pager");
-
-            _liquidParseFactory.RegisterTag<HelperTag>("helper");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("shape");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("link");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("meta");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("resources");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("script");
-            _liquidParseFactory.RegisterTag<NamedHelperTag>("style");
-
-            _liquidParseFactory.RegisterBlock<HelperBlock>("block");
-            _liquidParseFactory.RegisterBlock<NamedHelperBlock>("a");
-            _liquidParseFactory.RegisterBlock<NamedHelperBlock>("zone");
-            _liquidParseFactory.RegisterBlock<NamedHelperBlock>("scriptblock");
-
-            _liquidParseFactory.RegisterBlock<CacheBlock>("cache");
-            _liquidParseFactory.RegisterTag<CacheDependencyTag>("cache_dependency");
-            _liquidParseFactory.RegisterTag<CacheExpiresOnTag>("cache_expires_on");
-            _liquidParseFactory.RegisterTag<CacheExpiresAfterTag>("cache_expires_after");
-            _liquidParseFactory.RegisterTag<CacheExpiresSlidingTag>("cache_expires_sliding");
         }
     }
 }

--- a/PoExtractor.Razor/PoExtractor.Razor.csproj
+++ b/PoExtractor.Razor/PoExtractor.Razor.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\PoExtractor.DotNet\PoExtractor.DotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="3.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.0" />
   </ItemGroup>
 </Project>

--- a/PoExtractor.Razor/ViewCompiler.cs
+++ b/PoExtractor.Razor/ViewCompiler.cs
@@ -40,10 +40,11 @@ namespace PoExtractor.Razor
                     .ConfigureClass((document, @class) => {
                         @class.ClassName = Path.GetFileNameWithoutExtension(document.Source.FilePath);
                     });
-
+#if NETSTANDARD2_0
                 FunctionsDirective.Register(builder);
                 InheritsDirective.Register(builder);
                 SectionDirective.Register(builder);
+#endif
             });
 
             return projectEngine;

--- a/PoExtractor/PoExtractor.csproj
+++ b/PoExtractor/PoExtractor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>PoExtractor</AssemblyName>
     <ToolCommandName>extractpo</ToolCommandName>
     <PackAsTool>true</PackAsTool>

--- a/PoExtractor/PoExtractor.csproj
+++ b/PoExtractor/PoExtractor.csproj
@@ -6,13 +6,13 @@
     <AssemblyName>PoExtractor</AssemblyName>
     <ToolCommandName>extractpo</ToolCommandName>
     <PackAsTool>true</PackAsTool>
-    <Version>0.3.1</Version>
+    <Version>0.4.0</Version>
     <PackageId>PoExtractor</PackageId>
     <Authors>Lukas Kabrt</Authors>
     <Company />
     <Product />
     <Description>.NET Core global tool for extractiong translatable strings from the .cs and .cshtml files.</Description>
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,9 @@ or
 
 or
 
-`extractpo-oc inputpath outputpath --liquid`
+`extractpo-oc inputpath outputpath`
 
-Extracts all translatable strings from projects at the specified input path and saves generated POT files at the specified output path. It creates one POT file per a project.
-
-Use the `--liquid` flag to include also .liquid files in the processing.
+Extracts all translatable strings from projects at the specified input path and saves generated POT files at the specified output path. It creates one POT file per a project. This includes liquid views.
 
 ## Uninstallation
 


### PR DESCRIPTION
fixes #33 

There were 2 apparent issues: 
- The extractor was crashing while parsing razor files. This [comment ](https://github.com/toddams/RazorLight/pull/278#issuecomment-555146492)helped me figure it out.
- New liquid blocks in OC were excluding some files from the extraction. I switched it to use the OC FluidTemplateFactory instead of a copy.

I also removed the liquid argument as I think it's redundant.