### PR TITLE
Added file sort by name in EnumerateFiles call to eliminate inconsistencies in file listing between OS types

### DIFF
--- a/PoExtractor.Core.Tests/Fakes/FakeCSharpProjectProcessor.cs
+++ b/PoExtractor.Core.Tests/Fakes/FakeCSharpProjectProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PoExtractor.Core.Contracts;
@@ -32,7 +33,7 @@ namespace PoExtractor.Core.Tests.Fakes
                         new DataAnnotationStringExtractor(codeMetadataProvider)
                 }, strings);
 
-            foreach (var file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories))
+            foreach (var file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories).OrderBy(file => file))
             {
                 using (var stream = File.OpenRead(file))
                 {

--- a/PoExtractor.DotNet.CS/CSharpProjectProcessor.cs
+++ b/PoExtractor.DotNet.CS/CSharpProjectProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PoExtractor.Core;
@@ -21,7 +22,7 @@ namespace PoExtractor.DotNet.CS {
                         new DataAnnotationStringExtractor(codeMetadataProvider)
                 }, strings);
 
-            foreach (var file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)) {
+            foreach (var file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories).OrderBy(file => file)) {
                 if (Path.GetFileName(file).EndsWith(".cshtml.g.cs")) {
                     continue;
                 }

--- a/PoExtractor.DotNet.VB/VisualBasicProjectProcessor.cs
+++ b/PoExtractor.DotNet.VB/VisualBasicProjectProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using PoExtractor.Core;
@@ -26,7 +27,7 @@ namespace PoExtractor.DotNet.VB
                     new DataAnnotationStringExtractor(codeMetadataProvider)
                 }, strings);
 
-            foreach (var file in Directory.EnumerateFiles(path, "*.vb", SearchOption.AllDirectories))
+            foreach (var file in Directory.EnumerateFiles(path, "*.vb", SearchOption.AllDirectories).OrderBy(file => file))
             {
                 if (Path.GetFileName(file).EndsWith(".cshtml.g.cs"))
                 {

--- a/PoExtractor.Liquid/LiquidProjectProcessor.cs
+++ b/PoExtractor.Liquid/LiquidProjectProcessor.cs
@@ -4,6 +4,7 @@ using PoExtractor.Core;
 using PoExtractor.Core.Contracts;
 using PoExtractor.Liquid.MetadataProviders;
 using System.IO;
+using System.Linq;
 
 namespace PoExtractor.Liquid {
     /// <summary>
@@ -24,7 +25,7 @@ namespace PoExtractor.Liquid {
             var liquidMetadataProvider = new LiquidMetadataProvider(basePath);
             var liquidVisitor = new ExtractingLiquidWalker(new[] { new LiquidStringExtractor(liquidMetadataProvider) }, strings);
             
-            foreach (var file in Directory.EnumerateFiles(path, "*.liquid", SearchOption.AllDirectories)) {
+            foreach (var file in Directory.EnumerateFiles(path, "*.liquid", SearchOption.AllDirectories).OrderBy(file => file)) {
                 using (var stream = File.OpenRead(file)) {
                     using (var reader = new StreamReader(stream)) {
 

--- a/PoExtractor.OrchardCore/Program.cs
+++ b/PoExtractor.OrchardCore/Program.cs
@@ -22,8 +22,8 @@ namespace PoExtractor.OrchardCore {
 
             string[] projectFiles;
             if (Directory.Exists(basePath)) {
-                projectFiles = Directory.EnumerateFiles(basePath, $"*{ProjectExtension.CS}", SearchOption.AllDirectories)
-                    .Union(Directory.EnumerateFiles(basePath, $"*{ProjectExtension.VB}", SearchOption.AllDirectories)).ToArray();
+                projectFiles = Directory.EnumerateFiles(basePath, $"*{ProjectExtension.CS}", SearchOption.AllDirectories).OrderBy(file => file)
+                    .Union(Directory.EnumerateFiles(basePath, $"*{ProjectExtension.VB}", SearchOption.AllDirectories).OrderBy(file => file)).ToArray();
             } else {
                 WriteHelp();
                 return;

--- a/PoExtractor.Razor/ViewCompiler.cs
+++ b/PoExtractor.Razor/ViewCompiler.cs
@@ -10,15 +10,15 @@ namespace PoExtractor.Razor
     {
         public static IList<RazorPageGeneratorResult> CompileViews(string projectDirectory)
         {
-            var projectEngine = CreateProjectEngine("PoExtraxtor.GeneratedCode", projectDirectory);
+            var projectEngine = CreateProjectEngine("PoExtractor.GeneratedCode", projectDirectory);
 
             var results = new List<RazorPageGeneratorResult>();
 
-            var viewDirectories = Directory.EnumerateDirectories(projectDirectory, "Views", SearchOption.AllDirectories);
+            var viewDirectories = Directory.EnumerateDirectories(projectDirectory, "Views", SearchOption.AllDirectories).OrderBy(dirName => dirName);
             foreach (var viewDir in viewDirectories)
             {
                 var viewDirPath = viewDir.Substring(projectDirectory.Length).Replace('\\', '/');
-                var viewFiles = projectEngine.FileSystem.EnumerateItems(viewDirPath);
+                var viewFiles = projectEngine.FileSystem.EnumerateItems(viewDirPath).OrderBy(rzrProjItem => rzrProjItem.FileName);
 
                 foreach (var item in viewFiles.Where(o => o.Extension == ".cshtml"))
                 {

--- a/PoExtractor/Program.cs
+++ b/PoExtractor/Program.cs
@@ -20,8 +20,8 @@ namespace PoExtractor {
 
             string[] projectFiles;
             if (Directory.Exists(basePath)) {
-                projectFiles = Directory.EnumerateFiles(basePath, $"*{ProjectExtension.CS}", SearchOption.AllDirectories)
-                    .Union(Directory.EnumerateFiles(basePath, $"*{ProjectExtension.VB}", SearchOption.AllDirectories)).ToArray();
+                projectFiles = Directory.EnumerateFiles(basePath, $"*{ProjectExtension.CS}", SearchOption.AllDirectories).OrderBy(file => file)
+                    .Union(Directory.EnumerateFiles(basePath, $"*{ProjectExtension.VB}", SearchOption.AllDirectories).OrderBy(file => file)).ToArray();
             } else {
                 WriteHelp();
                 return;


### PR DESCRIPTION
Small change to address issue with EnumerateFiles as described in https://stackoverflow.com/questions/14097264/directory-enumeratefiles-read-order

It can cause some annoyances when maintaining the same pot file in a repo when developers are using different OS types.