### PR TITLE
Support Pages folder for Razor Pages

### DIFF
--- a/PoExtractor.Core.Tests/LocalizableStringCollectionTests.cs
+++ b/PoExtractor.Core.Tests/LocalizableStringCollectionTests.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Xunit;
 
 namespace PoExtractor.Core.Tests {
-    public class LocalizableStringCollcationTests {
+    public class LocalizableStringCollectionTests {
         private LocalizableStringOccurence s1 = new LocalizableStringOccurence() { Text = "Computer", Location = new LocalizableStringLocation() { SourceFileLine = 1 } };
         private LocalizableStringOccurence s2 = new LocalizableStringOccurence() { Text = "Computer", Location = new LocalizableStringLocation() { SourceFileLine = 1 } };
         private LocalizableStringOccurence otherS = new LocalizableStringOccurence() { Text = "Keyboard", Location = new LocalizableStringLocation() { SourceFileLine = 1 } };

--- a/PoExtractor.Razor/ViewCompiler.cs
+++ b/PoExtractor.Razor/ViewCompiler.cs
@@ -14,7 +14,13 @@ namespace PoExtractor.Razor
 
             var results = new List<RazorPageGeneratorResult>();
 
-            var viewDirectories = Directory.EnumerateDirectories(projectDirectory, "Views", SearchOption.AllDirectories).OrderBy(dirName => dirName);
+            // MVC uses the Views folder as convention.
+            // Razor Pages uses the Pages folder as convention. 
+            // Both use Areas as convention and either have Pages or Views as subfolders.
+            var viewDirectories = Directory.EnumerateDirectories(projectDirectory, "Views", SearchOption.AllDirectories)
+                .Concat(Directory.EnumerateDirectories(projectDirectory, "Pages", SearchOption.AllDirectories))
+                .Distinct()
+                .OrderBy(dirName => dirName);
             foreach (var viewDir in viewDirectories)
             {
                 var viewDirPath = viewDir.Substring(projectDirectory.Length).Replace('\\', '/');

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,10 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.103'
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.x'
   inputs:
-    version: 2.2.103
+    version: '3.1.x'
 
 - task: DotNetCoreCLI@2
   displayName: Restore

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "3.1.200",
+		"rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
Include the Pages folder so cshtml for Razor Pages are inspected as well, not just MVC Views. 
fixes #38 